### PR TITLE
nl80211: Correct the usage of command NL80211_CMD_VENDOR

### DIFF
--- a/net/wireless/nl80211.c
+++ b/net/wireless/nl80211.c
@@ -6765,9 +6765,11 @@ static int nl80211_vendor_cmd(struct sk_buff *skb, struct genl_info *info)
 			data = nla_data(info->attrs[NL80211_ATTR_VENDOR_DATA]);
 			len = nla_len(info->attrs[NL80211_ATTR_VENDOR_DATA]);
 		}
-
-		return rdev->wiphy.vendor_commands[i].doit(&rdev->wiphy, wdev,
+		rdev->cur_cmd_info = info;
+		err = rdev->wiphy.vendor_commands[i].doit(&rdev->wiphy, wdev,
 							   data, len);
+		rdev->cur_cmd_info = NULL;
+		return err;
 	}
 
 	return -EOPNOTSUPP;


### PR DESCRIPTION
Assign/pass the cur_cmd_info parameter correctly. This fixes a
merge error when open source commit
ad7e718c9b4f717823fd920a0103f7b0fb06183f was pulled into the tree.

CRs-Fixed: 672390
Change-Id: Iaa21a1723709683a6f34b07423b74ef0b6077b68
Signed-off-by: Sunil Dutt usdutt@codeaurora.org
